### PR TITLE
Fixed base64 in OpenCL kernel and added several useful features

### DIFF
--- a/src/generator/vanity.cl
+++ b/src/generator/vanity.cl
@@ -335,7 +335,7 @@ __constant char sEncodingTable[] = {
       'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
       'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
       'w', 'x', 'y', 'z', '0', '1', '2', '3',
-      '4', '5', '6', '7', '8', '9', '+', '/'
+      '4', '5', '6', '7', '8', '9', '-', '_'
 };
 
 void encode_base64(char * data, uint dataLen, char * result);


### PR DESCRIPTION
When trying to use the app, I have discovered that it has an issue and is missing some useful features.

Fixes:
- OpenCL kernel had invalid characters (+, /) in base64 encoding, changed them to correct (-, _) ones - it was impossible to look for vanity address with - or _ characters because of that bug.

Features:
- It is now possible to search for only one address, especially if difficulty is high, so that as not to waste power on continuing search after the first address is first.
- Ability to check the prefix starting from 3rd character (UQxxx...) was added (opposing to default 4th UQ?xxxx...), that will allow to more finely tune your address if you know and understand restrictions on these first characters.